### PR TITLE
Add a nack handler for customized actions for explicit nacks.

### DIFF
--- a/server.go
+++ b/server.go
@@ -47,7 +47,7 @@ var (
 type Nack struct {
 	Action NackAction
 	// VisibilityTimeout allows setting a visibility timeout when nacking. This delays the time before the message is available for processing.
-	VisibilityTimeout int
+	VisibilityTimeoutSeconds int
 }
 
 type NackHandlerFunc func(msg *http.Request) Nack
@@ -378,8 +378,8 @@ func (s *SQSServer) serveMessage(ctx context.Context, q *queue, m types.Message,
 				q.Metrics(MetricNack, durationMillis(start), int(atomic.LoadInt32(&q.inprocess)))
 				switch nack.Action {
 				case NackExtend:
-					if nack.VisibilityTimeout > 0 {
-						s.heartbeat(ctx, q, m, int32(nack.VisibilityTimeout))
+					if nack.VisibilityTimeoutSeconds > 0 {
+						s.heartbeat(ctx, q, m, int32(nack.VisibilityTimeoutSeconds))
 					}
 				}
 			}

--- a/server.go
+++ b/server.go
@@ -115,7 +115,6 @@ func New(conf aws.Config, h http.Handler) (*SQSServer, error) {
 	return NewWithOptions(Options{
 		AWSConf: conf,
 		Handler: h,
-		Nack:    nil,
 	})
 }
 
@@ -125,6 +124,9 @@ func NewWithOptions(opts Options) (*SQSServer, error) {
 	}
 	if opts.Handler == nil {
 		opts.Handler = http.DefaultServeMux
+	}
+	if opts.Nack == nil {
+		opts.Nack = DefaultNackHandler
 	}
 	if opts.AWSConf.HTTPClient == nil {
 		// For backwards compatibility, set this http client if one is not already set.


### PR DESCRIPTION
Add a customizable nack handler.

As a backoff mechanism callers can extend the visibility timeout on an explicit nack.  
Future options can include re-enqueueing the message with a delay time.